### PR TITLE
ios 26メディアの再生問題のメモリ対応　

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVWebViewEngine/CDVWebViewEngine.m
@@ -217,7 +217,7 @@
 
     // Do not configure the scheme handler if the scheme is default (file)
     if(!self.cdvIsFileScheme) {
-        self.schemeHandler = [[CDVURLSchemeHandler alloc] initWithVC:vc];
+        self.schemeHandler = [[CDVURLSchemeHandler alloc] initWithViewController:self.viewController];
         [configuration setURLSchemeHandler:self.schemeHandler forURLScheme:scheme];
     }
 

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -50,20 +50,15 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
-    NSLog(@"[CDVURLSchemeHandler] startURLSchemeTask called for URL: %@", urlSchemeTask.request.URL);
-    
     // Give plugins the chance to handle the url
     NSDictionary *pluginObjects = [[self.viewController pluginObjects] copy];
-    NSLog(@"[CDVURLSchemeHandler] Checking %lu plugins for URL handling", (unsigned long)pluginObjects.count);
-    
+
     for (NSString* pluginName in pluginObjects) {
         CDVPlugin *plugin = [self.viewController.pluginObjects objectForKey:pluginName];
         SEL selector = NSSelectorFromString(@"overrideSchemeTask:");
         if ([plugin respondsToSelector:selector]) {
-            NSLog(@"[CDVURLSchemeHandler] Plugin %@ can handle scheme task", pluginName);
             BOOL handledRequest = (((BOOL (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
             if (handledRequest) {
-                NSLog(@"[CDVURLSchemeHandler] Plugin %@ handled the request", pluginName);
                 // Store the plugin that is handling this particular request
                 [self.handlerMap setObject:plugin forKey:urlSchemeTask];
                 return;
@@ -72,29 +67,22 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
     }
 
     NSURLRequest *req = urlSchemeTask.request;
-    NSLog(@"[CDVURLSchemeHandler] Request scheme: %@, expected scheme: %@", req.URL.scheme, self.viewController.appScheme);
-    
+
     if (![req.URL.scheme isEqualToString:self.viewController.appScheme]) {
-        NSLog(@"[CDVURLSchemeHandler] Scheme mismatch, ignoring request");
         return;
     }
 
     // Indicate that we are handling this task, by adding an entry with a null plugin
     // We do this so that we can (in future) detect if the task is cancelled before we finished feeding it response data
     [self.handlerMap setObject:(id)[NSNull null] forKey:urlSchemeTask];
-    NSLog(@"[CDVURLSchemeHandler] Starting background processing for URL: %@", req.URL);
 
     [self.viewController.commandDelegate runInBackground:^{
-        NSLog(@"[CDVURLSchemeHandler] Background thread started for URL: %@", req.URL);
-        
         NSURL *fileURL = [self fileURLForRequestURL:req.URL];
-        NSLog(@"[CDVURLSchemeHandler] Resolved file URL: %@", fileURL);
-        
+
         NSError *error;
 
         NSFileHandle *fileHandle = [NSFileHandle fileHandleForReadingFromURL:fileURL error:&error];
         if (!fileHandle || error) {
-            NSLog(@"[CDVURLSchemeHandler] Failed to open file: %@, error: %@", fileURL, error);
             if ([self taskActive:urlSchemeTask]) {
                 [urlSchemeTask didFailWithError:error];
             }
@@ -109,8 +97,6 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
         NSString *mimeType = [self getMimeType:fileURL] ?: @"application/octet-stream";
         NSNumber *fileLength;
         [fileURL getResourceValue:&fileLength forKey:NSURLFileSizeKey error:nil];
-        
-        NSLog(@"[CDVURLSchemeHandler] File info - MIME: %@, Size: %@ bytes", mimeType, fileLength);
 
         NSNumber *responseSize = fileLength;
         NSUInteger responseSent = 0;
@@ -123,8 +109,7 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
         // Check for Range header - only for media files
         NSString *rangeHeader = [urlSchemeTask.request valueForHTTPHeaderField:@"Range"];
         BOOL isMediaFile = [self isMediaFile:fileURL mimeType:mimeType];
-        NSLog(@"[CDVURLSchemeHandler] Range header: %@, Is media file: %@", rangeHeader, isMediaFile ? @"YES" : @"NO");
-        
+
         if (rangeHeader && isMediaFile) {
             NSRange range = NSMakeRange(NSNotFound, 0);
 
@@ -134,13 +119,11 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
                 NSUInteger start = (NSUInteger)[rangeParts[0] integerValue];
                 NSUInteger end = rangeParts.count > 1 && ![rangeParts[1] isEqualToString:@""] ? (NSUInteger)[rangeParts[1] integerValue] : [fileLength unsignedIntegerValue] - 1;
                 range = NSMakeRange(start, end - start + 1);
-                NSLog(@"[CDVURLSchemeHandler] Parsed range: %lu-%lu (length: %lu)", (unsigned long)range.location, (unsigned long)(range.location + range.length - 1), (unsigned long)range.length);
             }
 
             if (range.location != NSNotFound) {
                 // Ensure range is valid
                 if (range.location >= [fileLength unsignedIntegerValue] && [self taskActive:urlSchemeTask]) {
-                    NSLog(@"[CDVURLSchemeHandler] Range out of bounds, returning 416");
                     headers[@"Content-Range"] = [NSString stringWithFormat:@"bytes */%@", fileLength];
                     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:req.URL statusCode:416 HTTPVersion:@"HTTP/1.1" headerFields:headers];
                     [urlSchemeTask didReceiveResponse:response];
@@ -157,25 +140,21 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
                 statusCode = 206; // Partial Content
                 headers[@"Content-Range"] = [NSString stringWithFormat:@"bytes %lu-%lu/%@", (unsigned long)range.location, (unsigned long)(range.location + range.length - 1), fileLength];
                 headers[@"Content-Length"] = [NSString stringWithFormat:@"%lu", (unsigned long)range.length];
-                NSLog(@"[CDVURLSchemeHandler] Range request - Status: 206, Content-Range: %@", headers[@"Content-Range"]);
             }
         }
 
         NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:req.URL statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:headers];
-        NSLog(@"[CDVURLSchemeHandler] Sending response - Status: %ld, Headers: %@", (long)statusCode, headers);
-        
+
         if ([self taskActive:urlSchemeTask]) {
             [urlSchemeTask didReceiveResponse:response];
         }
 
         // Use chunked reading only for media files, otherwise read entire file
         if (isMediaFile) {
-            NSLog(@"[CDVURLSchemeHandler] Using chunked reading for media file");
             while ([self taskActive:urlSchemeTask] && responseSent < [responseSize unsignedIntegerValue]) {
                 @autoreleasepool {
                     NSData *data = [self readFromFileHandle:fileHandle upTo:FILE_BUFFER_SIZE error:&error];
                     if (!data || error) {
-                        NSLog(@"[CDVURLSchemeHandler] Error reading chunk: %@", error);
                         if ([self taskActive:urlSchemeTask]) {
                             [urlSchemeTask didFailWithError:error];
                         }
@@ -184,21 +163,17 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
                     if ([self taskActive:urlSchemeTask]) {
                         [urlSchemeTask didReceiveData:data];
-                        NSLog(@"[CDVURLSchemeHandler] Sent chunk: %lu bytes (total sent: %lu)", (unsigned long)data.length, (unsigned long)(responseSent + data.length));
                     }
 
                     responseSent += data.length;
                 }
             }
         } else {
-            NSLog(@"[CDVURLSchemeHandler] Using single read for non-media file");
             // For non-media files, read entire file at once (original behavior)
             NSData *data = [self readFromFileHandle:fileHandle upTo:[responseSize unsignedIntegerValue] error:&error];
             if (data && [self taskActive:urlSchemeTask]) {
                 [urlSchemeTask didReceiveData:data];
-                NSLog(@"[CDVURLSchemeHandler] Sent entire file: %lu bytes", (unsigned long)data.length);
             } else if (error && [self taskActive:urlSchemeTask]) {
-                NSLog(@"[CDVURLSchemeHandler] Error reading entire file: %@", error);
                 [urlSchemeTask didFailWithError:error];
             }
         }
@@ -207,9 +182,6 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
         if ([self taskActive:urlSchemeTask]) {
             [urlSchemeTask didFinish];
-            NSLog(@"[CDVURLSchemeHandler] Task completed successfully");
-        } else {
-            NSLog(@"[CDVURLSchemeHandler] Task was cancelled before completion");
         }
 
         @synchronized(self.handlerMap) {
@@ -220,8 +192,6 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
 - (void)webView:(nonnull WKWebView *)webView stopURLSchemeTask:(nonnull id<WKURLSchemeTask>)urlSchemeTask
 {
-    NSLog(@"[CDVURLSchemeHandler] stopURLSchemeTask called for URL: %@", urlSchemeTask.request.URL);
-    
     CDVPlugin *plugin;
     @synchronized(self.handlerMap) {
         plugin = [self.handlerMap objectForKey:urlSchemeTask];
@@ -230,19 +200,13 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
     if (![plugin isEqual:[NSNull null]]) {
     SEL selector = NSSelectorFromString(@"stopSchemeTask:");
         if ([plugin respondsToSelector:selector]) {
-            NSLog(@"[CDVURLSchemeHandler] Calling stopSchemeTask on plugin");
             (((void (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
-        } else {
-            NSLog(@"[CDVURLSchemeHandler] Plugin does not respond to stopSchemeTask");
         }
-    } else {
-        NSLog(@"[CDVURLSchemeHandler] No plugin handling this task");
     }
 
     @synchronized(self.handlerMap) {
         [self.handlerMap removeObjectForKey:urlSchemeTask];
     }
-    NSLog(@"[CDVURLSchemeHandler] Task removed from handler map");
 }
 
 #pragma mark - Utility methods
@@ -255,34 +219,29 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
         NSString *path = [url.path stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
         // For _app_file_ paths, use the path directly without www folder
         filePath = [NSURL fileURLWithPath:path];
-        NSLog(@"[CDVURLSchemeHandler] Using _app_file_ path directly: %@", path);
     } else {
         // For regular paths, use www folder
         NSURL *resDir = [[NSBundle mainBundle] URLForResource:self.viewController.wwwFolderName withExtension:nil];
         if ([url.path isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
             filePath = [resDir URLByAppendingPathComponent:self.viewController.startPage];
-            NSLog(@"[CDVURLSchemeHandler] Using start page: %@", self.viewController.startPage);
         } else {
             filePath = [resDir URLByAppendingPathComponent:url.path];
-            NSLog(@"[CDVURLSchemeHandler] Using direct path: %@", url.path);
         }
     }
 
     NSURL *result = filePath.URLByStandardizingPath;
-    NSLog(@"[CDVURLSchemeHandler] Final file URL: %@", result);
     return result;
 }
 
 -(NSString *)getMimeType:(NSURL *)url
 {
     NSString *mimeType = nil;
-    
+
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
     if (@available(iOS 14.0, *)) {
         UTType *uti;
         [url getResourceValue:&uti forKey:NSURLContentTypeKey error:nil];
         mimeType = [uti preferredMIMEType];
-        NSLog(@"[CDVURLSchemeHandler] iOS 14+ MIME type: %@", mimeType);
     }
 #endif
 
@@ -290,9 +249,8 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
         NSString *type;
         [url getResourceValue:&type forKey:NSURLTypeIdentifierKey error:nil];
         mimeType = (__bridge NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassMIMEType);
-        NSLog(@"[CDVURLSchemeHandler] Legacy MIME type: %@", mimeType);
     }
-    
+
     return mimeType ?: @"application/octet-stream";
 }
 
@@ -336,21 +294,18 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 {
     // Check by file extension
     BOOL isMediaByExtension = [self isMediaExtension:fileURL.pathExtension];
-    NSLog(@"[CDVURLSchemeHandler] Extension check: %@ -> %@", fileURL.pathExtension, isMediaByExtension ? @"YES" : @"NO");
-    
+
     if (isMediaByExtension) {
         return YES;
     }
-    
+
     // Check by MIME type
     NSArray *audioMimeTypes = @[@"audio/m4a", @"audio/mp3", @"audio/mp4", @"audio/mpeg", @"audio/vnd.wave", @"audio/wav"];
     NSArray *videoMimeTypes = @[@"video/mp4", @"video/quicktime"];
-    
-    BOOL isMediaByMime = [audioMimeTypes containsObject:mimeType.lowercaseString] || 
+
+    BOOL isMediaByMime = [audioMimeTypes containsObject:mimeType.lowercaseString] ||
                         [videoMimeTypes containsObject:mimeType.lowercaseString];
-    
-    NSLog(@"[CDVURLSchemeHandler] MIME type check: %@ -> %@", mimeType, isMediaByMime ? @"YES" : @"NO");
-    
+
     return isMediaByMime;
 }
 

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -249,14 +249,16 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
 - (NSURL *)fileURLForRequestURL:(NSURL *)url
 {
-    NSURL *resDir = [[NSBundle mainBundle] URLForResource:self.viewController.wwwFolderName withExtension:nil];
     NSURL *filePath;
 
     if ([url.path hasPrefix:@"/_app_file_"]) {
         NSString *path = [url.path stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
-        filePath = [resDir URLByAppendingPathComponent:path];
-        NSLog(@"[CDVURLSchemeHandler] Using _app_file_ path: %@", path);
+        // For _app_file_ paths, use the path directly without www folder
+        filePath = [NSURL fileURLWithPath:path];
+        NSLog(@"[CDVURLSchemeHandler] Using _app_file_ path directly: %@", path);
     } else {
+        // For regular paths, use www folder
+        NSURL *resDir = [[NSBundle mainBundle] URLForResource:self.viewController.wwwFolderName withExtension:nil];
         if ([url.path isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
             filePath = [resDir URLByAppendingPathComponent:self.viewController.startPage];
             NSLog(@"[CDVURLSchemeHandler] Using start page: %@", self.viewController.startPage);

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -50,14 +50,20 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
+    NSLog(@"[CDVURLSchemeHandler] startURLSchemeTask called for URL: %@", urlSchemeTask.request.URL);
+    
     // Give plugins the chance to handle the url
     NSDictionary *pluginObjects = [[self.viewController pluginObjects] copy];
+    NSLog(@"[CDVURLSchemeHandler] Checking %lu plugins for URL handling", (unsigned long)pluginObjects.count);
+    
     for (NSString* pluginName in pluginObjects) {
         CDVPlugin *plugin = [self.viewController.pluginObjects objectForKey:pluginName];
         SEL selector = NSSelectorFromString(@"overrideSchemeTask:");
         if ([plugin respondsToSelector:selector]) {
+            NSLog(@"[CDVURLSchemeHandler] Plugin %@ can handle scheme task", pluginName);
             BOOL handledRequest = (((BOOL (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
             if (handledRequest) {
+                NSLog(@"[CDVURLSchemeHandler] Plugin %@ handled the request", pluginName);
                 // Store the plugin that is handling this particular request
                 [self.handlerMap setObject:plugin forKey:urlSchemeTask];
                 return;
@@ -66,20 +72,29 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
     }
 
     NSURLRequest *req = urlSchemeTask.request;
+    NSLog(@"[CDVURLSchemeHandler] Request scheme: %@, expected scheme: %@", req.URL.scheme, self.viewController.appScheme);
+    
     if (![req.URL.scheme isEqualToString:self.viewController.appScheme]) {
+        NSLog(@"[CDVURLSchemeHandler] Scheme mismatch, ignoring request");
         return;
     }
 
     // Indicate that we are handling this task, by adding an entry with a null plugin
     // We do this so that we can (in future) detect if the task is cancelled before we finished feeding it response data
     [self.handlerMap setObject:(id)[NSNull null] forKey:urlSchemeTask];
+    NSLog(@"[CDVURLSchemeHandler] Starting background processing for URL: %@", req.URL);
 
     [self.viewController.commandDelegate runInBackground:^{
+        NSLog(@"[CDVURLSchemeHandler] Background thread started for URL: %@", req.URL);
+        
         NSURL *fileURL = [self fileURLForRequestURL:req.URL];
+        NSLog(@"[CDVURLSchemeHandler] Resolved file URL: %@", fileURL);
+        
         NSError *error;
 
         NSFileHandle *fileHandle = [NSFileHandle fileHandleForReadingFromURL:fileURL error:&error];
         if (!fileHandle || error) {
+            NSLog(@"[CDVURLSchemeHandler] Failed to open file: %@, error: %@", fileURL, error);
             if ([self taskActive:urlSchemeTask]) {
                 [urlSchemeTask didFailWithError:error];
             }
@@ -94,6 +109,8 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
         NSString *mimeType = [self getMimeType:fileURL] ?: @"application/octet-stream";
         NSNumber *fileLength;
         [fileURL getResourceValue:&fileLength forKey:NSURLFileSizeKey error:nil];
+        
+        NSLog(@"[CDVURLSchemeHandler] File info - MIME: %@, Size: %@ bytes", mimeType, fileLength);
 
         NSNumber *responseSize = fileLength;
         NSUInteger responseSent = 0;
@@ -105,7 +122,10 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
         // Check for Range header - only for media files
         NSString *rangeHeader = [urlSchemeTask.request valueForHTTPHeaderField:@"Range"];
-        if (rangeHeader && [self isMediaFile:fileURL mimeType:mimeType]) {
+        BOOL isMediaFile = [self isMediaFile:fileURL mimeType:mimeType];
+        NSLog(@"[CDVURLSchemeHandler] Range header: %@, Is media file: %@", rangeHeader, isMediaFile ? @"YES" : @"NO");
+        
+        if (rangeHeader && isMediaFile) {
             NSRange range = NSMakeRange(NSNotFound, 0);
 
             if ([rangeHeader hasPrefix:@"bytes="]) {
@@ -114,11 +134,13 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
                 NSUInteger start = (NSUInteger)[rangeParts[0] integerValue];
                 NSUInteger end = rangeParts.count > 1 && ![rangeParts[1] isEqualToString:@""] ? (NSUInteger)[rangeParts[1] integerValue] : [fileLength unsignedIntegerValue] - 1;
                 range = NSMakeRange(start, end - start + 1);
+                NSLog(@"[CDVURLSchemeHandler] Parsed range: %lu-%lu (length: %lu)", (unsigned long)range.location, (unsigned long)(range.location + range.length - 1), (unsigned long)range.length);
             }
 
             if (range.location != NSNotFound) {
                 // Ensure range is valid
                 if (range.location >= [fileLength unsignedIntegerValue] && [self taskActive:urlSchemeTask]) {
+                    NSLog(@"[CDVURLSchemeHandler] Range out of bounds, returning 416");
                     headers[@"Content-Range"] = [NSString stringWithFormat:@"bytes */%@", fileLength];
                     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:req.URL statusCode:416 HTTPVersion:@"HTTP/1.1" headerFields:headers];
                     [urlSchemeTask didReceiveResponse:response];
@@ -135,20 +157,25 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
                 statusCode = 206; // Partial Content
                 headers[@"Content-Range"] = [NSString stringWithFormat:@"bytes %lu-%lu/%@", (unsigned long)range.location, (unsigned long)(range.location + range.length - 1), fileLength];
                 headers[@"Content-Length"] = [NSString stringWithFormat:@"%lu", (unsigned long)range.length];
+                NSLog(@"[CDVURLSchemeHandler] Range request - Status: 206, Content-Range: %@", headers[@"Content-Range"]);
             }
         }
 
         NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:req.URL statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:headers];
+        NSLog(@"[CDVURLSchemeHandler] Sending response - Status: %ld, Headers: %@", (long)statusCode, headers);
+        
         if ([self taskActive:urlSchemeTask]) {
             [urlSchemeTask didReceiveResponse:response];
         }
 
         // Use chunked reading only for media files, otherwise read entire file
-        if ([self isMediaFile:fileURL mimeType:mimeType]) {
+        if (isMediaFile) {
+            NSLog(@"[CDVURLSchemeHandler] Using chunked reading for media file");
             while ([self taskActive:urlSchemeTask] && responseSent < [responseSize unsignedIntegerValue]) {
                 @autoreleasepool {
                     NSData *data = [self readFromFileHandle:fileHandle upTo:FILE_BUFFER_SIZE error:&error];
                     if (!data || error) {
+                        NSLog(@"[CDVURLSchemeHandler] Error reading chunk: %@", error);
                         if ([self taskActive:urlSchemeTask]) {
                             [urlSchemeTask didFailWithError:error];
                         }
@@ -157,17 +184,21 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
                     if ([self taskActive:urlSchemeTask]) {
                         [urlSchemeTask didReceiveData:data];
+                        NSLog(@"[CDVURLSchemeHandler] Sent chunk: %lu bytes (total sent: %lu)", (unsigned long)data.length, (unsigned long)(responseSent + data.length));
                     }
 
                     responseSent += data.length;
                 }
             }
         } else {
+            NSLog(@"[CDVURLSchemeHandler] Using single read for non-media file");
             // For non-media files, read entire file at once (original behavior)
             NSData *data = [self readFromFileHandle:fileHandle upTo:[responseSize unsignedIntegerValue] error:&error];
             if (data && [self taskActive:urlSchemeTask]) {
                 [urlSchemeTask didReceiveData:data];
+                NSLog(@"[CDVURLSchemeHandler] Sent entire file: %lu bytes", (unsigned long)data.length);
             } else if (error && [self taskActive:urlSchemeTask]) {
+                NSLog(@"[CDVURLSchemeHandler] Error reading entire file: %@", error);
                 [urlSchemeTask didFailWithError:error];
             }
         }
@@ -176,6 +207,9 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
         if ([self taskActive:urlSchemeTask]) {
             [urlSchemeTask didFinish];
+            NSLog(@"[CDVURLSchemeHandler] Task completed successfully");
+        } else {
+            NSLog(@"[CDVURLSchemeHandler] Task was cancelled before completion");
         }
 
         @synchronized(self.handlerMap) {
@@ -186,21 +220,29 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
 - (void)webView:(nonnull WKWebView *)webView stopURLSchemeTask:(nonnull id<WKURLSchemeTask>)urlSchemeTask
 {
+    NSLog(@"[CDVURLSchemeHandler] stopURLSchemeTask called for URL: %@", urlSchemeTask.request.URL);
+    
     CDVPlugin *plugin;
     @synchronized(self.handlerMap) {
         plugin = [self.handlerMap objectForKey:urlSchemeTask];
     }
 
     if (![plugin isEqual:[NSNull null]]) {
-        SEL selector = NSSelectorFromString(@"stopSchemeTask:");
+    SEL selector = NSSelectorFromString(@"stopSchemeTask:");
         if ([plugin respondsToSelector:selector]) {
+            NSLog(@"[CDVURLSchemeHandler] Calling stopSchemeTask on plugin");
             (((void (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
+        } else {
+            NSLog(@"[CDVURLSchemeHandler] Plugin does not respond to stopSchemeTask");
         }
+    } else {
+        NSLog(@"[CDVURLSchemeHandler] No plugin handling this task");
     }
 
     @synchronized(self.handlerMap) {
         [self.handlerMap removeObjectForKey:urlSchemeTask];
     }
+    NSLog(@"[CDVURLSchemeHandler] Task removed from handler map");
 }
 
 #pragma mark - Utility methods
@@ -213,30 +255,43 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
     if ([url.path hasPrefix:@"/_app_file_"]) {
         NSString *path = [url.path stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
         filePath = [resDir URLByAppendingPathComponent:path];
+        NSLog(@"[CDVURLSchemeHandler] Using _app_file_ path: %@", path);
     } else {
         if ([url.path isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
             filePath = [resDir URLByAppendingPathComponent:self.viewController.startPage];
+            NSLog(@"[CDVURLSchemeHandler] Using start page: %@", self.viewController.startPage);
         } else {
             filePath = [resDir URLByAppendingPathComponent:url.path];
+            NSLog(@"[CDVURLSchemeHandler] Using direct path: %@", url.path);
         }
     }
 
-    return filePath.URLByStandardizingPath;
+    NSURL *result = filePath.URLByStandardizingPath;
+    NSLog(@"[CDVURLSchemeHandler] Final file URL: %@", result);
+    return result;
 }
 
 -(NSString *)getMimeType:(NSURL *)url
 {
+    NSString *mimeType = nil;
+    
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
     if (@available(iOS 14.0, *)) {
         UTType *uti;
         [url getResourceValue:&uti forKey:NSURLContentTypeKey error:nil];
-        return [uti preferredMIMEType];
+        mimeType = [uti preferredMIMEType];
+        NSLog(@"[CDVURLSchemeHandler] iOS 14+ MIME type: %@", mimeType);
     }
 #endif
 
-    NSString *type;
-    [url getResourceValue:&type forKey:NSURLTypeIdentifierKey error:nil];
-    return (__bridge NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassMIMEType);
+    if (!mimeType) {
+        NSString *type;
+        [url getResourceValue:&type forKey:NSURLTypeIdentifierKey error:nil];
+        mimeType = (__bridge NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassMIMEType);
+        NSLog(@"[CDVURLSchemeHandler] Legacy MIME type: %@", mimeType);
+    }
+    
+    return mimeType ?: @"application/octet-stream";
 }
 
 - (nullable NSData *)readFromFileHandle:(NSFileHandle *)handle upTo:(NSUInteger)length error:(NSError **)err
@@ -278,7 +333,10 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 - (BOOL)isMediaFile:(NSURL *)fileURL mimeType:(NSString *)mimeType
 {
     // Check by file extension
-    if ([self isMediaExtension:fileURL.pathExtension]) {
+    BOOL isMediaByExtension = [self isMediaExtension:fileURL.pathExtension];
+    NSLog(@"[CDVURLSchemeHandler] Extension check: %@ -> %@", fileURL.pathExtension, isMediaByExtension ? @"YES" : @"NO");
+    
+    if (isMediaByExtension) {
         return YES;
     }
     
@@ -286,12 +344,12 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
     NSArray *audioMimeTypes = @[@"audio/m4a", @"audio/mp3", @"audio/mp4", @"audio/mpeg", @"audio/vnd.wave", @"audio/wav"];
     NSArray *videoMimeTypes = @[@"video/mp4", @"video/quicktime"];
     
-    if ([audioMimeTypes containsObject:mimeType.lowercaseString] || 
-        [videoMimeTypes containsObject:mimeType.lowercaseString]) {
-        return YES;
-    }
+    BOOL isMediaByMime = [audioMimeTypes containsObject:mimeType.lowercaseString] || 
+                        [videoMimeTypes containsObject:mimeType.lowercaseString];
     
-    return NO;
+    NSLog(@"[CDVURLSchemeHandler] MIME type check: %@ -> %@", mimeType, isMediaByMime ? @"YES" : @"NO");
+    
+    return isMediaByMime;
 }
 
 @end

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -19,119 +19,277 @@
 
 
 #import <Cordova/CDVURLSchemeHandler.h>
+#import <Cordova/CDVViewController.h>
+#import <Cordova/CDVPlugin.h>
+#import <Foundation/Foundation.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 
 #import <objc/message.h>
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#endif
+
+static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
+
+@interface CDVURLSchemeHandler ()
+
+@end
+
 @implementation CDVURLSchemeHandler
 
-
-- (instancetype)initWithVC:(CDVViewController *)controller
+- (instancetype)initWithViewController:(CDVViewController *)controller
 {
     self = [super init];
     if (self) {
         _viewController = controller;
+        _handlerMap = [NSMapTable weakToWeakObjectsMapTable];
     }
     return self;
 }
 
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask
 {
-    NSString * startPath = [[NSBundle mainBundle] pathForResource:self.viewController.wwwFolderName ofType: nil];
-    NSURL * url = urlSchemeTask.request.URL;
-    NSString * stringToLoad = url.path;
-    NSString * scheme = url.scheme;
-    
-    CDVViewController* vc = (CDVViewController*)self.viewController;
-
-    /*
-     * Give plugins the chance to handle the url
-     */
-    BOOL anyPluginsResponded = NO;
-    BOOL handledRequest = NO;
-
-    NSDictionary *pluginObjects = [[vc pluginObjects] copy];
+    // Give plugins the chance to handle the url
+    NSDictionary *pluginObjects = [[self.viewController pluginObjects] copy];
     for (NSString* pluginName in pluginObjects) {
-        self.schemePlugin = [vc.pluginObjects objectForKey:pluginName];
+        CDVPlugin *plugin = [self.viewController.pluginObjects objectForKey:pluginName];
         SEL selector = NSSelectorFromString(@"overrideSchemeTask:");
-        if ([self.schemePlugin respondsToSelector:selector]) {
-            handledRequest = (((BOOL (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(self.schemePlugin, selector, urlSchemeTask));
+        if ([plugin respondsToSelector:selector]) {
+            BOOL handledRequest = (((BOOL (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
             if (handledRequest) {
-                anyPluginsResponded = YES;
-                break;
+                // Store the plugin that is handling this particular request
+                [self.handlerMap setObject:plugin forKey:urlSchemeTask];
+                return;
             }
         }
     }
 
-    if (!anyPluginsResponded) {
-        if ([scheme isEqualToString:self.viewController.appScheme]) {
-            if ([stringToLoad hasPrefix:@"/_app_file_"]) {
-                startPath = [stringToLoad stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
-            } else {
-                if ([stringToLoad isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
-                    startPath = [startPath stringByAppendingPathComponent:self.viewController.startPage];
-                } else {
-                    startPath = [startPath stringByAppendingPathComponent:stringToLoad];
+    NSURLRequest *req = urlSchemeTask.request;
+    if (![req.URL.scheme isEqualToString:self.viewController.appScheme]) {
+        return;
+    }
+
+    // Indicate that we are handling this task, by adding an entry with a null plugin
+    // We do this so that we can (in future) detect if the task is cancelled before we finished feeding it response data
+    [self.handlerMap setObject:(id)[NSNull null] forKey:urlSchemeTask];
+
+    [self.viewController.commandDelegate runInBackground:^{
+        NSURL *fileURL = [self fileURLForRequestURL:req.URL];
+        NSError *error;
+
+        NSFileHandle *fileHandle = [NSFileHandle fileHandleForReadingFromURL:fileURL error:&error];
+        if (!fileHandle || error) {
+            if ([self taskActive:urlSchemeTask]) {
+                [urlSchemeTask didFailWithError:error];
+            }
+
+            @synchronized(self.handlerMap) {
+                [self.handlerMap removeObjectForKey:urlSchemeTask];
+            }
+            return;
+        }
+
+        NSInteger statusCode = 200; // Default to 200 OK status
+        NSString *mimeType = [self getMimeType:fileURL] ?: @"application/octet-stream";
+        NSNumber *fileLength;
+        [fileURL getResourceValue:&fileLength forKey:NSURLFileSizeKey error:nil];
+
+        NSNumber *responseSize = fileLength;
+        NSUInteger responseSent = 0;
+
+        NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithCapacity:5];
+        headers[@"Content-Type"] = mimeType;
+        headers[@"Cache-Control"] = @"no-cache";
+        headers[@"Content-Length"] = [responseSize stringValue];
+
+        // Check for Range header - only for media files
+        NSString *rangeHeader = [urlSchemeTask.request valueForHTTPHeaderField:@"Range"];
+        if (rangeHeader && [self isMediaFile:fileURL mimeType:mimeType]) {
+            NSRange range = NSMakeRange(NSNotFound, 0);
+
+            if ([rangeHeader hasPrefix:@"bytes="]) {
+                NSString *byteRange = [rangeHeader substringFromIndex:6];
+                NSArray<NSString *> *rangeParts = [byteRange componentsSeparatedByString:@"-"];
+                NSUInteger start = (NSUInteger)[rangeParts[0] integerValue];
+                NSUInteger end = rangeParts.count > 1 && ![rangeParts[1] isEqualToString:@""] ? (NSUInteger)[rangeParts[1] integerValue] : [fileLength unsignedIntegerValue] - 1;
+                range = NSMakeRange(start, end - start + 1);
+            }
+
+            if (range.location != NSNotFound) {
+                // Ensure range is valid
+                if (range.location >= [fileLength unsignedIntegerValue] && [self taskActive:urlSchemeTask]) {
+                    headers[@"Content-Range"] = [NSString stringWithFormat:@"bytes */%@", fileLength];
+                    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:req.URL statusCode:416 HTTPVersion:@"HTTP/1.1" headerFields:headers];
+                    [urlSchemeTask didReceiveResponse:response];
+                    [urlSchemeTask didFinish];
+
+                    @synchronized(self.handlerMap) {
+                        [self.handlerMap removeObjectForKey:urlSchemeTask];
+                    }
+                    return;
+                }
+
+                [fileHandle seekToFileOffset:range.location];
+                responseSize = [NSNumber numberWithUnsignedInteger:range.length];
+                statusCode = 206; // Partial Content
+                headers[@"Content-Range"] = [NSString stringWithFormat:@"bytes %lu-%lu/%@", (unsigned long)range.location, (unsigned long)(range.location + range.length - 1), fileLength];
+                headers[@"Content-Length"] = [NSString stringWithFormat:@"%lu", (unsigned long)range.length];
+            }
+        }
+
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:req.URL statusCode:statusCode HTTPVersion:@"HTTP/1.1" headerFields:headers];
+        if ([self taskActive:urlSchemeTask]) {
+            [urlSchemeTask didReceiveResponse:response];
+        }
+
+        // Use chunked reading only for media files, otherwise read entire file
+        if ([self isMediaFile:fileURL mimeType:mimeType]) {
+            while ([self taskActive:urlSchemeTask] && responseSent < [responseSize unsignedIntegerValue]) {
+                @autoreleasepool {
+                    NSData *data = [self readFromFileHandle:fileHandle upTo:FILE_BUFFER_SIZE error:&error];
+                    if (!data || error) {
+                        if ([self taskActive:urlSchemeTask]) {
+                            [urlSchemeTask didFailWithError:error];
+                        }
+                        break;
+                    }
+
+                    if ([self taskActive:urlSchemeTask]) {
+                        [urlSchemeTask didReceiveData:data];
+                    }
+
+                    responseSent += data.length;
                 }
             }
-        }
-
-        NSError * fileError = nil;
-        NSData * data = nil;
-        if ([self isMediaExtension:url.pathExtension]) {
-            data = [NSData dataWithContentsOfFile:startPath options:NSDataReadingMappedIfSafe error:&fileError];
-        }
-        if (!data || fileError) {
-            data =  [[NSData alloc] initWithContentsOfFile:startPath];
-        }
-        NSInteger statusCode = 200;
-        if (!data) {
-            statusCode = 404;
-        }
-        NSURL * localUrl = [NSURL URLWithString:url.absoluteString];
-        NSString * mimeType = [self getMimeType:url.pathExtension];
-        id response = nil;
-        if (data && [self isMediaExtension:url.pathExtension]) {
-            response = [[NSURLResponse alloc] initWithURL:localUrl MIMEType:mimeType expectedContentLength:data.length textEncodingName:nil];
         } else {
-            NSDictionary * headers = @{ @"Content-Type" : mimeType, @"Cache-Control": @"no-cache"};
-            response = [[NSHTTPURLResponse alloc] initWithURL:localUrl statusCode:statusCode HTTPVersion:nil headerFields:headers];
+            // For non-media files, read entire file at once (original behavior)
+            NSData *data = [self readFromFileHandle:fileHandle upTo:[responseSize unsignedIntegerValue] error:&error];
+            if (data && [self taskActive:urlSchemeTask]) {
+                [urlSchemeTask didReceiveData:data];
+            } else if (error && [self taskActive:urlSchemeTask]) {
+                [urlSchemeTask didFailWithError:error];
+            }
         }
 
-        [urlSchemeTask didReceiveResponse:response];
-        if (data) {
-            [urlSchemeTask didReceiveData:data];
+        [fileHandle closeFile];
+
+        if ([self taskActive:urlSchemeTask]) {
+            [urlSchemeTask didFinish];
         }
-        [urlSchemeTask didFinish];
-    }
+
+        @synchronized(self.handlerMap) {
+            [self.handlerMap removeObjectForKey:urlSchemeTask];
+        }
+    }];
 }
 
 - (void)webView:(nonnull WKWebView *)webView stopURLSchemeTask:(nonnull id<WKURLSchemeTask>)urlSchemeTask
 {
+    CDVPlugin *plugin;
+    @synchronized(self.handlerMap) {
+        plugin = [self.handlerMap objectForKey:urlSchemeTask];
+    }
+
+    if (![plugin isEqual:[NSNull null]] && [plugin respondsToSelector:@selector(stopSchemeTask:)]) {
     SEL selector = NSSelectorFromString(@"stopSchemeTask:");
-    if (self.schemePlugin != nil && [self.schemePlugin respondsToSelector:selector]) {
-        (((void (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(self.schemePlugin, selector, urlSchemeTask));
+        (((void (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
+    }
+
+    @synchronized(self.handlerMap) {
+        [self.handlerMap removeObjectForKey:urlSchemeTask];
     }
 }
 
--(NSString *) getMimeType:(NSString *)fileExtension {
-    if (fileExtension && ![fileExtension isEqualToString:@""]) {
-        NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, NULL);
-        NSString *contentType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
-        return contentType ? contentType : @"application/octet-stream";
+#pragma mark - Utility methods
+
+- (NSURL *)fileURLForRequestURL:(NSURL *)url
+{
+    NSURL *resDir = [[NSBundle mainBundle] URLForResource:self.viewController.wwwFolderName withExtension:nil];
+    NSURL *filePath;
+
+    if ([url.path hasPrefix:@"/_app_file_"]) {
+        NSString *path = [url.path stringByReplacingOccurrencesOfString:@"/_app_file_" withString:@""];
+        filePath = [resDir URLByAppendingPathComponent:path];
     } else {
-        return @"text/html";
+        if ([url.path isEqualToString:@""] || [url.pathExtension isEqualToString:@""]) {
+            filePath = [resDir URLByAppendingPathComponent:self.viewController.startPage];
+        } else {
+            filePath = [resDir URLByAppendingPathComponent:url.path];
+        }
+    }
+
+    return filePath.URLByStandardizingPath;
+}
+
+-(NSString *)getMimeType:(NSURL *)url
+{
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+    if (@available(iOS 14.0, *)) {
+        UTType *uti;
+        [url getResourceValue:&uti forKey:NSURLContentTypeKey error:nil];
+        return [uti preferredMIMEType];
+    }
+#endif
+
+    NSString *type;
+    [url getResourceValue:&type forKey:NSURLTypeIdentifierKey error:nil];
+    return (NSString *)UTTypeCopyPreferredTagWithClass((CFStringRef)type, kUTTagClassMIMEType);
+}
+
+- (nullable NSData *)readFromFileHandle:(NSFileHandle *)handle upTo:(NSUInteger)length error:(NSError **)err
+{
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+    if (@available(iOS 14.0, *)) {
+        return [handle readDataUpToLength:length error:err];
+    }
+#endif
+
+    @try {
+        return [handle readDataOfLength:length];
+    }
+    @catch (NSError *error) {
+        if (err != nil) {
+            *err = error;
+        }
+        return nil;
     }
 }
 
--(BOOL) isMediaExtension:(NSString *) pathExtension {
-    NSArray * mediaExtensions = @[@"m4v", @"mov", @"mp4",
-                           @"aac", @"ac3", @"aiff", @"au", @"flac", @"m4a", @"mp3", @"wav"];
+- (BOOL)taskActive:(id <WKURLSchemeTask>)task
+{
+    @synchronized(self.handlerMap) {
+        return [self.handlerMap objectForKey:task] != nil;
+    }
+}
+
+- (BOOL)isMediaExtension:(NSString *)pathExtension
+{
+    NSArray *mediaExtensions = @[@"m4v", @"mov", @"mp4", @"mpeg",
+                           @"aac", @"ac3", @"aiff", @"au", @"flac", @"m4a", @"mp3", @"wav", @"wave"];
     if ([mediaExtensions containsObject:pathExtension.lowercaseString]) {
         return YES;
     }
     return NO;
 }
 
+- (BOOL)isMediaFile:(NSURL *)fileURL mimeType:(NSString *)mimeType
+{
+    // Check by file extension
+    if ([self isMediaExtension:fileURL.pathExtension]) {
+        return YES;
+    }
+    
+    // Check by MIME type
+    NSArray *audioMimeTypes = @[@"audio/m4a", @"audio/mp3", @"audio/mp4", @"audio/mpeg", @"audio/vnd.wave", @"audio/wav"];
+    NSArray *videoMimeTypes = @[@"video/mp4", @"video/quicktime"];
+    
+    if ([audioMimeTypes containsObject:mimeType.lowercaseString] || 
+        [videoMimeTypes containsObject:mimeType.lowercaseString]) {
+        return YES;
+    }
+    
+    return NO;
+}
 
 @end

--- a/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
+++ b/CordovaLib/Classes/Public/CDVURLSchemeHandler.m
@@ -191,9 +191,11 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
         plugin = [self.handlerMap objectForKey:urlSchemeTask];
     }
 
-    if (![plugin isEqual:[NSNull null]] && [plugin respondsToSelector:@selector(stopSchemeTask:)]) {
-    SEL selector = NSSelectorFromString(@"stopSchemeTask:");
-        (((void (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
+    if (![plugin isEqual:[NSNull null]]) {
+        SEL selector = NSSelectorFromString(@"stopSchemeTask:");
+        if ([plugin respondsToSelector:selector]) {
+            (((void (*)(id, SEL, id <WKURLSchemeTask>))objc_msgSend)(plugin, selector, urlSchemeTask));
+        }
     }
 
     @synchronized(self.handlerMap) {
@@ -234,7 +236,7 @@ static const NSUInteger FILE_BUFFER_SIZE = 1024 * 1024 * 4; // 4 MiB
 
     NSString *type;
     [url getResourceValue:&type forKey:NSURLTypeIdentifierKey error:nil];
-    return (NSString *)UTTypeCopyPreferredTagWithClass((CFStringRef)type, kUTTagClassMIMEType);
+    return (__bridge NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassMIMEType);
 }
 
 - (nullable NSData *)readFromFileHandle:(NSFileHandle *)handle upTo:(NSUInteger)length error:(NSError **)err

--- a/CordovaLib/Classes/Public/CDVViewController.m
+++ b/CordovaLib/Classes/Public/CDVViewController.m
@@ -164,6 +164,8 @@
         self.startPage = @"index.html";
     }
 
+    self.appScheme = [self.settings cordovaSettingForKey:@"Scheme"] ?: @"app";
+
     // Initialize the plugin objects dict.
     self.pluginObjects = [[NSMutableDictionary alloc] initWithCapacity:20];
 }

--- a/CordovaLib/include/Cordova/CDVURLSchemeHandler.h
+++ b/CordovaLib/include/Cordova/CDVURLSchemeHandler.h
@@ -24,11 +24,11 @@
 
 @interface CDVURLSchemeHandler : NSObject <WKURLSchemeHandler>
 
-@property (nonatomic, weak) CDVViewController* viewController;
+@property (nonatomic, assign) CDVViewController* viewController;
 
-@property (nonatomic) CDVPlugin* schemePlugin;
+@property (nonatomic, strong) NSMapTable <id <WKURLSchemeTask>, CDVPlugin *> *handlerMap;
 
-- (instancetype)initWithVC:(CDVViewController *)controller;
+- (instancetype)initWithViewController:(CDVViewController *)controller;
 
 
 @end

--- a/CordovaLib/include/Cordova/CDVViewController.h
+++ b/CordovaLib/include/Cordova/CDVViewController.h
@@ -65,7 +65,20 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) NSMutableDictionary* settings;
 @property (nonatomic, readonly, strong) NSXMLParser* configParser;
 
-@property (nonatomic, readwrite, copy) NSString* appScheme;
+/*
+ The scheme being used to load web content from the app bundle into the Cordova
+ web view.
+
+ The default value is `app` but can be customized via the `Scheme` preference
+ in the Cordova XML configuration file. Setting this to `file` will results in
+ web content being loaded using the File URL protocol, which has inherent
+ security limitations. It is encouraged that you use a custom scheme to load
+ your app content.
+
+ It is not valid to set this to an existing protocol scheme such as `http` or
+ `https`.
+ */
+@property (nonatomic, nullable, readwrite, copy) NSString* appScheme;
 @property (nonatomic, readwrite, copy) NSString* configFile;
 @property (nonatomic, readwrite, copy) NSString* wwwFolderName;
 @property (nonatomic, readwrite, copy) NSString* startPage;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "7.0.5-dev",
+  "version": "7.0.6-dev",
   "description": "cordova-ios release",
   "types": "./types/index.d.ts",
   "main": "lib/Api.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "7.0.4-dev",
+  "version": "7.0.5-dev",
   "description": "cordova-ios release",
   "types": "./types/index.d.ts",
   "main": "lib/Api.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "7.0.2-dev",
+  "version": "7.0.3-dev",
   "description": "cordova-ios release",
   "types": "./types/index.d.ts",
   "main": "lib/Api.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "7.0.6-dev",
+  "version": "7.1.0-dev",
   "description": "cordova-ios release",
   "types": "./types/index.d.ts",
   "main": "lib/Api.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-ios",
-  "version": "7.0.3-dev",
+  "version": "7.0.4-dev",
   "description": "cordova-ios release",
   "types": "./types/index.d.ts",
   "main": "lib/Api.js",


### PR DESCRIPTION
feat/wkwebview-config-customize　からBranchしていています。

issue: 
https://github.com/dejiren/rd-react-dejirenclient/issues/6200#issuecomment-3420853808

dejiren側に、schemeとhostnameを使用する場合、メディアを再生する際に、メモリが沢山使用され、wkWebViewが落ちます。

対策：
以下のcordova-ios　Ver8の機能を取り入れ、対応しました。
https://github.com/apache/cordova-ios/pull/1481


issue: https://github.com/apache/cordova-ios/issues/1033#event-19167834605

違い点：
cordova-ios　Ver8の機能では、全リソースファイルが対応。本修正では、Mediaファイル限定にしています。


